### PR TITLE
fix: make ci and secrets use updated central env name instead of ossrh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
           java-version: '21'
           cache: maven
           server-id: central
-          server-username: ${{ secrets.OSSRH_USERNAME }}
-          server-password: ${{ secrets.OSSRH_PASSWORD }}
+          server-username: ${{ secrets.CENTRAL_USERNAME }}
+          server-password: ${{ secrets.CENTRAL_PASSWORD }}
           gpg-private-key: ${{ secrets.SIGNING_KEY }}
           gpg-passphrase: ${{ secrets.SIGNING_PASSWORD }}
 

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -25,8 +25,8 @@ jobs:
           java-version: '21'
           cache: maven
           server-id: central
-          server-username: ${{ secrets.OSSRH_USERNAME }}
-          server-password: ${{ secrets.OSSRH_PASSWORD }}
+          server-username: ${{ secrets.CENTRAL_USERNAME }}
+          server-password: ${{ secrets.CENTRAL_PASSWORD }}
           gpg-private-key: ${{ secrets.SIGNING_KEY }}
           gpg-passphrase: ${{ secrets.SIGNING_PASSWORD }}
 


### PR DESCRIPTION
## Summary
- Updated the env vars in the workflow files so they reflect the correct repository secret

## Type
- [x] fix
- [ ] feat
- [ ] docs
- [ ] chore/test

## Checklist
- [x] Conventional Commit title
- [x] Tests added/updated
- [x] Docs updated


